### PR TITLE
Mexican Spanish Translation and small Spain Spanis Fix

### DIFF
--- a/src/main/resources/assets/elytratrims/lang/es_es.yml
+++ b/src/main/resources/assets/elytratrims/lang/es_es.yml
@@ -3,7 +3,7 @@ elytratrims:
     response:
       get_mode: "Modo %s actual es %s"
       set_mode: "Modo %s se ha cambiado al %s"
-      reset: Configuración reseteada!
+      reset: ¡Configuración reseteada!
   config:
     title: Elytra Trims
     category:

--- a/src/main/resources/assets/elytratrims/lang/es_mx.yml
+++ b/src/main/resources/assets/elytratrims/lang/es_mx.yml
@@ -1,0 +1,49 @@
+elytratrims:
+  command:
+    response:
+      get_mode: "Modo %s actual es %s"
+      set_mode: "Modo %s se ha cambiado al %s"
+      reset: ¡Configuración reseteada!
+  config:
+    title: Elytra Trims
+    category:
+      .: Configuración
+      render: Renderizado
+      texture: Textura
+    texture:
+      useBannerTextures:
+        .: Usa texturas de estandartes
+        tooltip: Usa las texturas del estandarte para los diseños de las Elytras en vez de para los escudos.
+      cropTrims:
+        .: Recortar diseños de armadura
+        tooltip: Recorta los diseños de armadura para que quepan en las Elytras.
+      useDarkerTrim:
+        .: Usar diseño de armadura oscuro
+        tooltip: "Usa un diseño de armadura para las Elytras, más oscuro si es posible.\nEsto usa el mismo color que cuando aplicas un diseño de armadura a una pieza del mismo material."
+      showBannerIcon:
+        .: Mostrar icono de estandarte
+        tooltip: Muestra el icono del estandarte en la Elytra.
+    type:
+      color:
+        .: Tinte
+        tooltip: Muestra Elytras tintadas.
+      cape:
+        .: Capa
+        tooltip: Muestra las texturas de capas en las Elytras.
+      glow:
+        .: Luminoso
+        tooltip: Haz brillar las características de las Elytras.
+      patterns:
+        .: Patrones
+        tooltip: Muestra los patrones de estandarte en las Elytras.
+      trims:
+        .: Diseños de armadura
+        tooltip: Muestra los diseños de armadura en las Elytras.
+      global:
+        .: Global
+        tooltip: Sobreescribe todos los otros tipos de renderizado.
+    mode:
+      none: Ninguno
+      self: Mismo
+      others: Otros
+      all: Todos


### PR DESCRIPTION
The mexican spanish translation changes de "Elitros" for "Elytras" which is use for most spanish translation across the official minecraft and other mods, plus it fixes some gramatical issus with the European Spanish translation, like the lack of use of conectors and commas