### PR TITLE
fix: don't include FMJ in (Neo)Forge builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -158,9 +158,11 @@ tasks.processResources {
         "mnd" to if (loader == "neoforge") "" else "mandatory = true"
     )
 
-    filesMatching("fabric.mod.json") { expand(map) }
-    filesMatching("META-INF/mods.toml") { expand(map) }
-    filesMatching("META-INF/neoforge.mods.toml") { expand(map) }
+    fun FileCopyDetails.expandOrExclude(expand: Boolean, map: Map<String, String>): Any = if (expand) expand(map) else exclude()
+
+    filesMatching("fabric.mod.json") { expandOrExclude(loader == "fabric", map) }
+    filesMatching("META-INF/mods.toml") { expandOrExclude(loader == "forge", map) }
+    filesMatching("META-INF/neoforge.mods.toml") { expandOrExclude(loader == "neoforge", map) }
 }
 
 yamlang {

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -24,6 +24,9 @@ config = "elytratrims-common.mixins.json"
 [[mixins]]
 config = "elytratrims-compat.mixins.json"
 
+[[accessTransformers]]
+file = "accesstransformer.cfg"
+
 [[dependencies.elytratrims]]
 modId = "minecraft"
 ${mnd}


### PR DESCRIPTION
Having an FMJ file in a (Neo)Forge build is **not supported** by Architectury Loom and causes [problems with access wideners](https://github.com/architectury/architectury-loom/issues/177) when other Arch Loom mods try to depend on the subject mod.